### PR TITLE
Search Image Result - creating tempfile to display results

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,6 +1,6 @@
 class ImagesController < ApplicationController
   before_action :set_image, only: [:show, :edit, :update, :destroy]
-
+  before_action :set_search_word_params, only: [:search_word_results, :search_image_png]
   # GET /images
   # GET /images.json
   def index
@@ -13,11 +13,11 @@ class ImagesController < ApplicationController
   end
 
   def search_word_results
-    @image = Image.find(params[:image_id])
-    @search_word = params[:search_word]
+  end
 
-    @image_with_search_results_highlighted = CreateBoundingBoxesOnImageProcessingService.new({image: @image, search_word: @search_word}).call[:marked_up_image]
-    @image_with_search_results_highlighted_path = @image_with_search_results_highlighted.path.partition(Rails.root.join("app", "assets", "images").to_s).last[1..-1]
+  def search_image_png
+    @file = CreateBoundingBoxesOnImageProcessingService.new({image: @image, search_word: @search_word}).call[:marked_up_image]
+    send_data @file.read, type: 'image/png', disposition: 'inline'
   end
 
   # GET /images/new
@@ -70,6 +70,11 @@ class ImagesController < ApplicationController
   end
 
   private
+
+    def set_search_word_params
+      @image = Image.find(params[:image_id])
+      @search_word = params[:search_word]
+    end
     
     # Use callbacks to share common setup or constraints between actions.
     def set_image

--- a/app/services/create_bounding_boxes_on_image_processing_service.rb
+++ b/app/services/create_bounding_boxes_on_image_processing_service.rb
@@ -55,7 +55,7 @@ class CreateBoundingBoxesOnImageProcessingService
 
     def temporarily_store_and_create_file(image=nil)
     	if @search_word_param
-    		file = File.new("#{Rails.root}/app/assets/images/temporary_uploads/search_results_#{@image.id}.png",'w')
+			file = Tempfile.new("search_results_#{@image.id}.png")    		
     	else
 			image.format = 'PNG'    	
 	    	file = Paperclip::Tempfile.new(["processed", ".png"])

--- a/app/views/images/search_word_results.html.erb
+++ b/app/views/images/search_word_results.html.erb
@@ -8,6 +8,6 @@ You can also submit another search:
 
 <%= render partial: "search_form" %>
 
-<%= image_tag @image_with_search_results_highlighted_path %>
+<%= image_tag image_search_image_png_path(search_word: @search_word) %> 
 
 <%= link_to 'All Images', images_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
 	resources :images do
 		get 'download_file'
 		get 'search_word_results'
+		get 'search_image_png'
 	end
 	# For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
Issue #1 - Although the last commit should have solved the issue in that marked up search images would have been displayed to users, these files were not being deleted despite not needing to be saved. Creating temporary files to display to users is a better approach. 